### PR TITLE
Added flexibility in patterns to avoid fails

### DIFF
--- a/lib/pytaf/taf.py
+++ b/lib/pytaf/taf.py
@@ -63,7 +63,7 @@ class TAF(object):
             ^
             TAF*    # TAF header (at times missing or duplicate)
             \s+
-            (?P<type> (COR|AMD|RTD)){0,1} # Corrected/Amended/Related
+            (?P<type> (COR|AMD|RTD)){0,1} # Corrected/Amended/Delayed
              
             \s* # There may or may not be space as COR/AMD/RTD is optional
             (?P<icao_code> [A-Z]{4}) # Station ICAO code
@@ -74,18 +74,18 @@ class TAF(object):
             (?P<origin_minutes> \d{0,2}) # at some aerodromes does not appear
             Z? # Zulu time (UTC, that is) # at some aerodromes does not appear
             
-            \s+
-            (?P<valid_from_date> \d{2})
-            (?P<valid_from_hours> \d{2})
-            /
-            (?P<valid_till_date> \d{2})
-            (?P<valid_till_hours> \d{2})
+            \s*
+            (?P<valid_from_date> \d{0,2})
+            (?P<valid_from_hours> \d{0,2})
+            /*
+            (?P<valid_till_date> \d{0,2})
+            (?P<valid_till_hours> \d{0,2})
         """
 
         header = re.match(taf_header_pattern, string, re.VERBOSE)
         
         if header:
-             return header.groupdict()
+            return header.groupdict()
         else:
             raise MalformedTAF("No valid TAF header found")
 
@@ -99,9 +99,9 @@ class TAF(object):
             MalformedTAF: Group decoding error
         
         """
-
+        
         taf_group_pattern = """
-            (?:Z\s+\d{4}/\d{4}|FM|PROB|TEMPO|BECMG)[A-Z0-9\+\-/\s$]+?(?=FM|PROB|TEMPO|BECMG|$)
+            (?:[\s\S]|FM|PROB|TEMPO|BECMG)[A-Z0-9\+\-/\s$]+?(?=FM|PROB|TEMPO|BECMG|$)
         """
 
         group_list = []


### PR DESCRIPTION
I'm testing thousands of TAF messages with your library and works very well. However some TAF messages (from countries around all the world) include different items or with variations and decoder fails. I'm forked your project and added some improvement to do Pytaf more flexible to avoid fails.
I changed in comments "Related" for "Delayed" (RTD stands for Routine Delayed).
If it's okay, feel free to merge the changes. In any case there are more issues that I find interesting include:
- Add remarks (RMK).
- create a new group in patterns (currently there are FM | PROB | TEMPO | BECMG, and there are another one not considered: PROB TEMPO (ie PROB40 TEMPO ....)).
  Thanks for yor great work!
