### PR TITLE
Parsing and translating METAR

### DIFF
--- a/lib/pytaf/taf.py
+++ b/lib/pytaf/taf.py
@@ -38,7 +38,7 @@ class TAF(object):
         self._taf_header = self._init_header(self._raw_taf)
         
         if self._taf_header['form'] == 'metar':
-            self._weather_groups = self._parse_metar(self._raw_taf)
+            self._weather_groups.append(self._parse_metar(self._raw_taf))
         else:
             # Get all TAF weather groups
             self._raw_weather_groups = self._init_groups(self._raw_taf)
@@ -65,7 +65,7 @@ class TAF(object):
         taf_header_pattern = """
             ^
             (TAF)?    # TAF header (at times missing or duplicate)
-            \s+
+            \s*
             (?P<type> (COR|AMD|RTD)){0,1} # Corrected/Amended/Delayed
              
             \s* # There may or may not be space as COR/AMD/RTD is optional
@@ -97,7 +97,7 @@ class TAF(object):
             (?P<origin_minutes> \d{0,2}) # at some aerodromes does not appear
             Z? # Zulu time (UTC, that is) # at some aerodromes does not appear
             \s+
-            (?P<type> (COR){0,1}) # Corrected
+            (?P<type> (COR){0,1}) # Corrected # TODO: Any other values possible?
         """
         
         header_taf = re.match(taf_header_pattern, string, re.VERBOSE)
@@ -376,9 +376,9 @@ class TAF(object):
         else:
             return(None)
 
-      # METAR specific functions
-      # TODO: Condition of runway
-      # TODO: Parse North American METAR codes
+    # METAR specific functions
+    # TODO: Condition of runway(s)
+    # TODO: Parse North American METAR codes
     def _parse_temperature(self, string):
         temperature_pattern = """
             (?<= \s )
@@ -414,6 +414,7 @@ class TAF(object):
             return(None)
 
     # TODO: Calculate relative/absolute humidity
+    # Nice-to-have - Not present in a METAR/TAF string, but it can be calculated by air temperature and dewpoint
 
     # Getters
     def get_taf(self):

--- a/lib/pytaf/taf.py
+++ b/lib/pytaf/taf.py
@@ -28,7 +28,7 @@ class TAF(object):
         if isinstance(string, str) and string != "":
             self._raw_taf = string
         else:
-            raise MalformedTAF("TAF string expected")
+            raise MalformedTAF("TAF/METAR string expected")
 
         # Patterns use ^ and $, so we don't want
         # leading/trailing spaces
@@ -38,7 +38,7 @@ class TAF(object):
         self._taf_header = self._init_header(self._raw_taf)
         
         if self._taf_header['form'] == 'metar':
-            self._weather_groups.append(self._parse_metar(self._raw_taf))
+            self._weather_groups.append(self._parse_group(self._raw_taf))
         else:
             # Get all TAF weather groups
             self._raw_weather_groups = self._init_groups(self._raw_taf)
@@ -146,8 +146,14 @@ class TAF(object):
 
     def _parse_group(self, string):
         group = {}
+        
+        if self._taf_header['form'] == "taf":
+            group["header"] = self._parse_group_header(string)
+        
+        if self._taf_header['form'] == "metar":
+            group["temperature"] = self._parse_temperature(string)
+            group["pressure"] = self._parse_pressure(string)
 
-        group["header"] = self._parse_group_header(string)
         group["wind"] = self._parse_wind(string)
         group["visibility"] = self._parse_visibility(string)
         group["clouds"] = self._parse_clouds(string)
@@ -156,21 +162,6 @@ class TAF(object):
         group["windshear"] = self._parse_wind_shear(string)
 
         return(group)
-    
-    def _parse_metar(self, string):
-        group = {}
-        
-        group["wind"] = self._parse_wind(string)
-        group["visibility"] = self._parse_visibility(string)
-        group["clouds"] = self._parse_clouds(string)
-        group["vertical_visibility"] = self._parse_vertical_visibility(string)
-        group["weather"] = self._parse_weather_phenomena(string)
-        group["windshear"] = self._parse_wind_shear(string)
-        group["temperature"] = self._parse_temperature(string)
-        group["pressure"] = self._parse_pressure(string)
-        
-        return(group)
-        
         
          
     def _parse_group_header(self, string):

--- a/lib/pytaf/taf.py
+++ b/lib/pytaf/taf.py
@@ -9,13 +9,13 @@ class TAF(object):
 
     def __init__(self, string):
         """ 
-        Initializes the object with TAF report text.
+        Initializes the object with TAF/METAR report text.
 
         Args:
-            string: TAF report string
+            string: TAF/METAR report string
 
         Raises:
-            MalformedTAF: An error parsing the TAF report
+            MalformedTAF: An error parsing the TAF/METAR report
         """
 
         # Instance variables
@@ -103,9 +103,9 @@ class TAF(object):
         header_taf = re.match(taf_header_pattern, string, re.VERBOSE)
         header_metar = re.match(metar_header_pattern, string, re.VERBOSE)
         
-        # As a METAR and TAF header doesn't differ that much it's likely
-        # to get both regex to match. TAF is a bit more specific so if
-        # both regex match we're most likely dealing with a TAF string.
+        # The difference between a METAR and TAF header isn't that big
+        # so it's likely to get both regex to match. TAF is a bit more specific so if
+        # both regex match then we're most likely dealing with a TAF string.
         if header_taf:
             header_dict = header_taf.groupdict()
             header_dict['form'] = 'taf'
@@ -305,7 +305,7 @@ class TAF(object):
         
         weather = []
 
-        # At first, find all weather strings in the TAF group.
+        # At first, find all weather strings in the TAF weather group or METAR string.
         weather_words = re.findall(weather_word_pattern, string, re.VERBOSE)
         for word in weather_words:
             intensities = []
@@ -334,7 +334,7 @@ class TAF(object):
                 word = word[chars_len:]
 
             # ...and put all three lists in a dictionary.
-            # There's a dictionary for each weather string found in a TAF group.
+            # There's a dictionary for each weather string found in a TAF weather group or METAR string.
             group_dict = {'intensity' : intensities, 'modifier' : modifiers, 'phenomenon' : phenomenons}
             weather.append(group_dict)
 
@@ -369,7 +369,7 @@ class TAF(object):
 
     # METAR specific functions
     # TODO: Condition of runway(s)
-    # TODO: Parse North American METAR codes
+    # TODO: Parse North American METAR codes (RMK)
     def _parse_temperature(self, string):
         temperature_pattern = """
             (?<= \s )

--- a/lib/pytaf/tafdecoder.py
+++ b/lib/pytaf/tafdecoder.py
@@ -18,39 +18,26 @@ class Decoder(object):
 
         result += self._decode_header(self._taf.get_header()) + "\n"
 
-        if form == "taf":
-            for group in self._taf.get_groups():
+        for group in self._taf.get_groups():
+            # TAF specific stuff
+            if form == "taf":
                 if group["header"]:
                     result += self._decode_group_header(group["header"]) + "\n"
 
-                if group["wind"]:
-                    result += "    Wind: %s \n" % self._decode_wind(group["wind"])
-
-                if group["visibility"]:
-                    result += "    Visibility: %s \n" % self._decode_visibility(group["visibility"])
-
-                if group["clouds"]:
-                    result += "    Sky conditions: %s \n" % self._decode_clouds(group["clouds"])
-
-                if group["weather"]:
-                    result += "    Weather: %s \n" % self._decode_weather(group["weather"])
-
-                if group["windshear"]:
-                    result += "    Windshear: %s\n" % self._decode_windshear(group["windshear"])
-        else:
-            group = self._taf.get_groups()
-
+            # METAR specific stuff
+            if form == "metar":
+                if group["temperature"]:
+                    result += "    Temperature: %s\n" % self._decode_temperature(group["temperature"])
+            
+                if group["pressure"]:
+                    result += "    Pressure: %s\n" % self._decode_pressure(group["pressure"])
+            
+            # Both TAF and METAR                    
             if group["wind"]:
                 result += "    Wind: %s \n" % self._decode_wind(group["wind"])
 
             if group["visibility"]:
                 result += "    Visibility: %s \n" % self._decode_visibility(group["visibility"])
-
-            if group["temperature"]:
-                result += "    Temperature: %s\n" % self._decode_temperature(group["temperature"])
-            
-            if group["pressure"]:
-                result += "    Pressure: %s\n" % self._decode_pressure(group["pressure"])
 
             if group["clouds"]:
                 result += "    Sky conditions: %s \n" % self._decode_clouds(group["clouds"])
@@ -60,8 +47,8 @@ class Decoder(object):
 
             if group["windshear"]:
                 result += "    Windshear: %s\n" % self._decode_windshear(group["windshear"])
-            
-        result += " \n"
+           
+            result += " \n"
 
         if self._taf.get_maintenance():
             result += self._decode_maintenance(self._taf.get_maintenance())
@@ -374,7 +361,7 @@ class Decoder(object):
 
         return(weather_txt_full)
     
-    def _decode_temperature(self, temperature):
+    def _decode_temperature(self, temperature, unit='C'):
         if temperature["air_prefix"] == 'M':
             air_c = int(temperature["air"])*-1
         else:
@@ -385,10 +372,17 @@ class Decoder(object):
         else:
             dew_c = int(temperature["dewpoint"])
         
-        air_f = int(round(air_c*1.8+32))
-        dew_f = int(round(dew_c*1.8+32))
+        if unit == 'C':
+            air_txt = air_c
+            dew_txt = dew_c
         
-        result = "air at %s°C/%s°F, dewpoint at %s°C/%s°F" % (air_c, air_f, dew_c, dew_f)
+        if unit == 'F':
+            air_f = int(round(air_c*1.8+32))
+            dew_f = int(round(dew_c*1.8+32))
+            air_txt = air_f
+            dew_txt = dew_f
+        
+        result = "air at %s°%s, dewpoint at %s°%s" % (air_txt, unit, dew_txt, unit)
         return(result)
     
     def _decode_pressure(self, pressure):

--- a/lib/pytaf/tafdecoder.py
+++ b/lib/pytaf/tafdecoder.py
@@ -286,8 +286,8 @@ class Decoder(object):
         weather_txt_blocks = []
 
         # Check for special cases first. If a certain combination is found
-        # skip parsing the whole weather string and return a defined string
-        # immidiately
+        # then skip parsing the whole weather string and return a defined string
+        # immediately
         for group in weather:
             # +FC = Tornado or Watersprout
             if "+" in group["intensity"] and "FC" in group["phenomenon"]:


### PR DESCRIPTION
Hi there!

Finally it's done. Sorry for the long wait. pytaf is now capable of parsing METAR announcements.
I tried to keep changes to the API as small as possible. The only thing I had to change was the header dict by adding a new key 'form' which contains either "taf" or "metar" as value. A given METAR string is also treated as an object of the 'TAF' class, so the naming might be a bit confusing here. There have to be changes in future releases in order to avoid that issue. The other option for renaming would be the creation of a separate class for processing METAR strings. Both classes could share a lot of in the TAF class existing parsing functions so it'd be better to put those functions in a separate class or make them globally accessible. How would you go about that?

Here's how it works currently:

Parsing:
- The parser tries to determine whether it has to deal with a TAF or METAR string. The header dict is then initialized with the approriate value for the key 'form'.
- If the parser has to deal with METAR then it's directly passed to _parse_group() and appended to the _weather_groups list. METAR doesn't provide more than one "weather group" so we don't need to loop it like we have to do with TAF. The 'weather_groups' list is created in both cases even if there's no need to create a list for only one element to insert. This happens due to compatibility reasons - the layout of _weather_groups stays the same.
- _parse_group() has been modified to check for possible elements in the given string only. For example METAR provides further information like temperatue and air pressure so it'd be useless to check for it when parsing a TAF. Most elements occur in both METAR and TAF so I guess there's no need for a seperate function.

Decoding:
- decode_taf() has been modified just like the way _parse_group() has. It checks the value in 'form' and applies the appropriate decoding functions to the given parsed data. 
- 2 new METAR specific decoding functions have been added: _decode_temperature() and _decode_pressure()

And that's it. The string in the 'result' var then gets built until all type specific groups are decoded and then returned as final output.


Issues:
I've never seen it before in reality but a short variant of the "valid from/to" identifier for TAF announcements seems to exist; an example of that being 131509 equivalent to '1315/1409'. If the short form is used and theres no 'TAF' or 'METAR' indicator at the beginning of the string then the parser will wrongly recognize the given TAF string as a METAR announcement. The library wasn't capable of handling short validity identifiers before so I didn't care about it that much. Nevertheless I consider it a missing feature that'll be implemented in a future pull request.
There are also several other values possible to parse in a METAR string. Just take a look at north american METAR announcements containing a so called "remarks section" indicated by the substring "RMK". There's still some work to do to parse that stuff - and I'd be happy to provide you with another contribution.

I've collected a few METAR and TAF issues of some bigger airports from all over the world for testing here: https://gist.github.com/redfawks/a64a64b4eae08c94d8b919aa76de3c8f . Everything seemed to work as expected - I hope it'll work out for you too! :)

Cheers!