### PR TITLE
Restore compatibility with Python 2 by declaring UTF-8 file encoding (#13)

### DIFF
--- a/lib/pytaf/tafdecoder.py
+++ b/lib/pytaf/tafdecoder.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import re
 from .taf import TAF
 


### PR DESCRIPTION
This fixed #13.